### PR TITLE
fix: github workflow improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,11 +41,11 @@ jobs:
           name: dist
           path: dist
 
+      # Install NPM dependencies, cache them correctly
+      # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          # we have already installed all dependencies above
-          install: false
           start: npm start
           wait-on: http://localhost:4200
           browser: chrome


### PR DESCRIPTION
This commit simplify workflow and adds some improvements.

Major changes:
- we shouldn't cache node_module because application could work differently on local machine and in pipeline.
- using of recommend `cypress-io/github-action@v2` that's already have built in Cypress binary caching.